### PR TITLE
Fix typo in landing-page.html

### DIFF
--- a/landing-page.html
+++ b/landing-page.html
@@ -111,7 +111,7 @@
               <li class="nav-item">
                   <a href="https://github.com/mdbootstrap/bootstrap-material-design" class="nav-link border border-light rounded"
                     target="_blank">
-                    <i class="fa fa-user mr-2"></i>Sing Up
+                    <i class="fa fa-user mr-2"></i>Sign Up
                   </a>
                 </li>
             </ul>


### PR DESCRIPTION
Hi!

There is a typo in the right `.navbar-nav`. The sign-up button is labeled `Sing Up` which is obviously a typo.

Cheers,
KevSlashNull